### PR TITLE
Adding payment register on the server.

### DIFF
--- a/server/Pipfile
+++ b/server/Pipfile
@@ -13,6 +13,7 @@ pyjwt = "*"
 flask-sqlalchemy = "*"
 flask-bcrypt = "*"
 psycopg2 = "*"
+stripe = "*"
 
 
 [requires]

--- a/server/api/payment_handler.py
+++ b/server/api/payment_handler.py
@@ -1,0 +1,26 @@
+from flask import jsonify, Blueprint, request
+import stripe
+
+payment_handler = Blueprint("payment_handler", __name__)
+
+stripe.api_key = "sk_test_51IB2YjBC6Uxj9HYv7iZBoYA6ijfWk2Y9dVJsxYfrfv0v1SGEcoct35vVVEBiPNYeqRxUDxikGcYSlqOT2PRThQfz00io3SSVC2"
+
+
+# Mock data
+def get_price_val(data):
+    return 1000, 'usd'
+
+
+@payment_handler.route("/api/create_payment", methods=["POST"])
+def create_payment():
+    try:
+        data = request.get_json()
+        price, currency = get_price_val(data)
+        intent = stripe.PaymentIntent.create(
+            amount=price,
+            currency=currency
+        )
+        return jsonify({"client_secret": intent["client_secret"]}), 201
+    except Exception as e:
+        return jsonify(error=str(e)), 403
+

--- a/server/app.py
+++ b/server/app.py
@@ -5,6 +5,7 @@ from api.home_handler import home_handler
 from api.contest_handler import contest_handler
 from api.user_handler import user_handler
 from api.submission_handler import submission_handler
+from api.payment_handler import payment_handler
 from config import S3_BUCKET, S3_KEY, S3_SECRET, S3_REGION
 import os
 import boto3
@@ -41,7 +42,6 @@ app.config['JWT_SECRET'] = os.environ.get('JWT_SECRET') if os.environ.get('JWT_S
 app.config['DOM_NAME'] = "http://localhost:3000"
 
 db.init_app(app)
-
 bcrypt.init_app(app)
 
 app.register_blueprint(user_handler)
@@ -49,3 +49,4 @@ app.register_blueprint(home_handler)
 app.register_blueprint(ping_handler)
 app.register_blueprint(contest_handler)
 app.register_blueprint(submission_handler)
+app.register_blueprint(payment_handler)


### PR DESCRIPTION
Back-end:
  This route is called when payment is registered in the FE, where the content they pay for, amount of money, and the currency is specified. 
  It will return a secret code identifying the payment back to the frontend and ask for their further payment information. 

- Only include a mock function that provides dummy data to test the API. Real data will require other components. 