### PR TITLE
Fixed how apiCalls should properly handle error messaging.

### DIFF
--- a/client/src/apiCalls.js
+++ b/client/src/apiCalls.js
@@ -1,9 +1,10 @@
 const hostname = "http://localhost:5000"
 
 class RequestError extends Error {
-    constructor(response) {
+    constructor(status, body) {
         super()
-        this.response = response
+        this.status = status
+        this.body = body
     }
 }
 
@@ -14,12 +15,12 @@ const get = async(subdom, onSucess, onError) => {
     })
     .then(response => {
         if (response.ok) {
-            const json = response.json()
-            return json
+            return response
         } else {
-            throw RequestError(response);
+            return response.json().then(err => Promise.reject(new RequestError(response.status, err)))
         }
     })
+    .then(response => response.json())
     .then(data => onSucess(data)) 
     .catch(error => onError(error))
 }
@@ -33,11 +34,12 @@ const makeRequest = async (subdom, callMethod, header, data, onSucess, onError) 
     })
     .then(response => {
         if (response.ok) {
-            return response.json()
+            return response
         } else {
-            throw RequestError(response)
+            return response.json().then(err => Promise.reject(new RequestError(response.status, err)))
         }
     })
+    .then(response => response.json())
     .then(data => onSucess(data)) 
     .catch(error => onError(error))
 }
@@ -46,14 +48,15 @@ const makeGETRequest = async (subdom, header, onSucess, onError) => {
     fetch(hostname+subdom, {
         headers: header,
         credentials: 'include'
-    }).
-    then(response => {
+    })
+    .then(response => {
         if (response.ok) {
-            return response.json()
+            return response
         } else {
-            throw RequestError(response)
+            return response.json().then(err => Promise.reject(new RequestError(response.status, err)))
         }
     })
+    .then(response => response.json())
     .then(data => onSucess(data))
     .catch(error => onError(error))
 }
@@ -98,7 +101,7 @@ export const getOwnedContests = async (userId, onSuccess, onError) => {
 }
 
 export const getContestDetails = async(contestId, onSuccess, onError) => {
-    get(`${hostname}/contest/${contestId}`, onSuccess, onError)
+    get(`/contest/${contestId}`, onSuccess, onError)
 }
 
 export default RequestError;

--- a/client/src/components/CreateContestForm.js
+++ b/client/src/components/CreateContestForm.js
@@ -97,8 +97,8 @@ export default function CreateContestForm() {
         createContest(title, description, amount, deadline, contestCreator, data => {
             console.log('contest has been successfully created!')
         }, error => {
-            if (error instanceof RequestError && error.response.status === 400) {
-                console.log(error.response.json())
+            if (error instanceof RequestError && error.status === 400) {
+                console.log(error.body)
             } else {
                 console.log("unexpected error")
             }

--- a/client/src/pages/ContestDetails.js
+++ b/client/src/pages/ContestDetails.js
@@ -122,8 +122,8 @@ export default function ContestDetails(props) {
             console.log(data)
             data.title ? setContest(data) : setContest(null)
         },  (error) => {
-            if (error instanceof RequestError && error.response.status === 400) {
-                console.log(error.response.json())
+            if (error instanceof RequestError && error.status === 400) {
+                console.log(error.body)
             } else {
                 console.log("unexpected error")
             }

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -70,8 +70,9 @@ const Login = () => {
                 console.log("SUCCESS")
             },  (error) => {
                 // onError
-                if (error instanceof RequestError && error.response.status === 400) {
-                    console.log(error.response.json())
+                console.log(error)
+                if (error instanceof RequestError && error.status === 400) {
+                    console.log(error.body)
                 } else {
                     console.log("unexpected error")
                 }

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -66,8 +66,8 @@ export default function Profile() {
             setContests(data) // Sets contests equal to return from get request
         }, (error) => {
             // onError
-            if (error instanceof RequestError && error.response.status === 400) {
-                console.log(error.response.json())
+            if (error instanceof RequestError && error.status === 400) {
+                console.log(error.body)
             } else {
                 console.log("unexpected error")
             }

--- a/client/src/pages/Signup.js
+++ b/client/src/pages/Signup.js
@@ -97,8 +97,8 @@ const Signup = () => {
                 console.log("SUCCESS")
             }, (error) => {
                 // onError
-                if (error instanceof RequestError && error.response.status == 400) {
-                    console.log(error.response.json())
+                if (error instanceof RequestError && error.status === 400) {
+                    console.log(error.body)
                 } else {
                     console.log("unexpected error")
                 }


### PR DESCRIPTION
This fix slightly changes the way how API calls works:
  Previously, any error status will result in a throw statement immediately, which causes a type error since the exception is not properly instantiated (without new). 
  Adding new, however, will surface the underlying problem the function originally has: response.json() is a Promise that will only get completed in the next then() chain. We essentially throw the Exception before the body is ever being requested in a condition of error. The new code will immediately resolves the Promise in place, so we could retain other useful information from the response (namely the status code) before it is lost in the next then() chain. 